### PR TITLE
Support DSN format without secret key.

### DIFF
--- a/src/crow.cpp
+++ b/src/crow.cpp
@@ -60,16 +60,16 @@ crow::crow(const std::string& dsn,
     // process DSN
     if (not dsn.empty())
     {
-        const std::regex dsn_regex("(http[s]?)://([^:]+):([^@]+)@([^/]+)/([0-9]+)");
+        const std::regex dsn_regex("(http[s]?)://([^:]+)(:([^@]+))?@([^/]+)/([0-9]+)");
         std::smatch pieces_match;
 
-        if (std::regex_match(dsn, pieces_match, dsn_regex) and pieces_match.size() == 6)
+        if (std::regex_match(dsn, pieces_match, dsn_regex) and pieces_match.size() == 7)
         {
             const auto scheme = pieces_match.str(1);
             m_public_key = pieces_match.str(2);
-            m_secret_key = pieces_match.str(3);
-            const auto host = pieces_match.str(4);
-            const auto project_id = pieces_match.str(5);
+            m_secret_key = pieces_match.str(4);
+            const auto host = pieces_match.str(5);
+            const auto project_id = pieces_match.str(6);
             m_store_url = scheme + "://" + host + "/api/" + project_id + "/store/";
         }
         else

--- a/tests/unittests.cpp
+++ b/tests/unittests.cpp
@@ -63,8 +63,13 @@ TEST_CASE("DSN parsing")
 {
     SECTION("valid DSN")
     {
+        // Deprecated DSN:
+        // "Deprecated DSN includes a secret which is no longer required by newer SDK versions."
         CHECK_NOTHROW(crow("http://abc:def@sentry.io/123"));
         CHECK_NOTHROW(crow("https://abc:def@sentry.io/123"));
+
+        // New DSN-format
+        CHECK_NOTHROW(crow("https://abc@sentry.io/123"));
     }
 
     SECTION("invalid DSN")


### PR DESCRIPTION
The DSN format changed, and a secret key is now not needed any more. In fact it is labeled as deprecated by Sentry.