### PR TITLE
CMake: FetchContent is much easier than external_project.

### DIFF
--- a/examples/integration/external_project/README.md
+++ b/examples/integration/external_project/README.md
@@ -2,6 +2,8 @@
 
 The integration as external project is a bit more complicated.
 
+*Note*: If you are using CMake version 3.14 or above, refer to the [fetch_content example][../fetch_content].
+
 Example:
 
 ```cmake

--- a/examples/integration/fetch_content/CMakeLists.txt
+++ b/examples/integration/fetch_content/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(crow_example)
+
+include(FetchContent)
+FetchContent_Declare(crow
+  GIT_REPOSITORY    https://github.com/nlohmann/crow
+  GIT_TAG           v0.0.6
+)
+FetchContent_MakeAvailable(crow)
+
+add_executable(example example.cpp)
+target_link_libraries(example crow)

--- a/examples/integration/fetch_content/README.md
+++ b/examples/integration/fetch_content/README.md
@@ -1,0 +1,22 @@
+# Integration using FetchContent
+
+The integration using the [`FetchContent`][1] module from CMake is very easy but requires CMake 3.14 or above. If you are stuck with previous versions of CMake, you may use the example from [../external_project].
+
+
+[1]: https://cmake.org/cmake/help/v3.18/module/FetchContent.html
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+
+project(crow_example)
+
+include(FetchContent)
+FetchContent_Declare(crow
+  GIT_REPOSITORY    https://github.com/nlohmann/crow
+  GIT_TAG           v0.0.6
+)
+FetchContent_MakeAvailable(crow)
+
+add_executable(example example.cpp)
+target_link_libraries(example crow)
+```

--- a/examples/integration/fetch_content/example.cpp
+++ b/examples/integration/fetch_content/example.cpp
@@ -1,0 +1,11 @@
+#include <crow/crow.hpp>
+
+using nlohmann::crow;
+
+int main()
+{
+    crow client("http://abc@sentry.io/42");
+
+    client.add_breadcrumb("this is a breadcrumb");
+    client.capture_message("this is a message");
+}


### PR DESCRIPTION
Here is how I just integrated *crow* into my project. 