### PR TITLE
Include `stdexcept` in `gzip_wrapper.cpp` to fix compilation

### DIFF
--- a/external/curl_wrapper/src/gzip_wrapper.cpp
+++ b/external/curl_wrapper/src/gzip_wrapper.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <stdexcept>
 #include <http/detail/gzip_wrapper.hpp>
 
 namespace http {


### PR DESCRIPTION
`std::runtime_error` is used in this file, but it had not been included.

I'm assuming after 2 years this has already been fixed in your work's fork, but I had to fix it for myself so I might as well put it here :^)